### PR TITLE
Update conda build to 2.0 and obvious-ci to conda-build-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
 
     # Need this for astropy-helpers
     - conda config --add channels astropy
+    # For ruamel.yaml
+    - conda config --add channels conda-forge
     - conda install astropy-helpers anaconda-client
 
     - conda update --quiet conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ install:
     - export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
     - conda config --set always_yes true
 
-    # Gets us Obvious-ci
-    - conda config --add channels conda-forge
-
     # Need this for astropy-helpers
     - conda config --add channels astropy
     - conda install astropy-helpers anaconda-client
@@ -28,7 +25,7 @@ install:
     - conda update --quiet conda
 
     # Install a couple of dependencies we need for sure.
-    - conda install --quiet --yes jinja2 conda-build=1.21.5 ruamel.yaml
+    - conda install --quiet --yes jinja2 conda-build=2.0* ruamel.yaml
 
 script:
     # Not much of a real test yet, just try to build myself...

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is a pair of scripts to create and manage a set of packages to be built
 with [`conda build`](https://github.com/conda/conda-build).
 
 The hard work is really done by `conda build` and
-[Obvious-CI](https://github.com/pelson/Obvious-CI)
-(soon to be replaced by [conda-build-all](https://github.com/SciTools/conda-build-all))
+[conda-build-all](https://github.com/SciTools/conda-build-all)
 
 ### extruder build status
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,14 +44,11 @@ install:
     - cmd: conda config --set always_yes true
     - cmd: conda update --quiet conda
 
-    # Gets us Obvious-ci
-    - cmd: conda config --add channels conda-forge
-
     # Need this for astropy-helpers
     - cmd: conda config --add channels astropy
     - cmd: conda install astropy-helpers
 
-    - cmd: conda install --quiet jinja2 conda-build=1.21.5 anaconda-client ruamel.yaml
+    - cmd: conda install --quiet jinja2 conda-build=2.0* anaconda-client ruamel.yaml
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,8 @@ install:
     - cmd: conda config --add channels astropy
     - cmd: conda install astropy-helpers
 
+    # Add for ruamel.yaml
+    - cmd: conda config --add channels conda-forge
     - cmd: conda install --quiet jinja2 conda-build=2.0* anaconda-client ruamel.yaml
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil

--- a/extruder.recipe/meta.yaml
+++ b/extruder.recipe/meta.yaml
@@ -17,9 +17,8 @@ requirements:
         - python
         - setuptools
         - conda
-        - conda-build
+        - conda-build 2.0*
         - anaconda-client
-        - obvious-ci
         - six
         - ruamel.yaml
         - ruamel.ordereddict   # [py26]

--- a/extruder/data/template-build-files/.travis.yml
+++ b/extruder/data/template-build-files/.travis.yml
@@ -8,7 +8,7 @@ os:
 
 env:
     global:
-        - DESTINATION_CONDA_CHANNEL = ""
+        - DESTINATION_CONDA_CHANNEL=""
         - TARGET_ARCH="x64"
         - CONDA_INSTALL_LOCN="${HOME}/miniconda"
 
@@ -38,21 +38,18 @@ install:
     - conda config --add channels astropy
     - conda config --add channels conda-forge
 
-    # Install obvious-ci.
-    - conda install -c conda-forge obvious-ci
+    - conda install conda-build=2.0*
 
+    # Install conda-build-all
+    - conda install -c conda-forge conda-build-all=1.0*
 
     # Finally, install extruder
     - conda install -c astropy extruder
 
-    # Install custom version of conda-build for now (need to be able to pass
-    # options to setup.py)
-    - conda remove --force conda-build
-    - conda install --force openssl=1.0.2d
-    - conda install -c astropy-ci-extras --override-channels conda-build=1.18.1
-
 script:
+    # Only upload if this is NOT a pull request.
+    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then UPLOAD="--upload-channels $DESTINATION_CONDA_CHANNEL"; else UPLOAD=""; fi'
     # Get ready to build.
     - extrude_recipes requirements.yml
     # Packages are uploaded as they are built.
-    - if [[ -d recipes ]]; then obvci_conda_build_dir --build-condition="python $PYTHON_BUILD_RESTRICTIONS" recipes $DESTINATION_CONDA_CHANNEL; fi
+    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS" --inspect-channels conda-forge $DESTINATION_CONDA_CHANNEL $UPLOAD; fi

--- a/extruder/data/template-build-files/appveyor.yml
+++ b/extruder/data/template-build-files/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   DESTINATION_CONDA_CHANNEL: ""
 
   # Appveyor machines come with miniconda already installed.
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
 
   # Need this to set up compilation on Windows.
   CMD_IN_ENV: cmd /E:ON /V:ON /C Obvious-CI\scripts\obvci_appveyor_python_build_env.cmd
@@ -52,23 +52,23 @@ install:
     - cmd: conda update --quiet conda
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
+    - cmd: conda install conda-build=2.0*
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
-    - cmd: conda install -c conda-forge obvious-ci
+    - cmd: conda install -c conda-forge conda-build-all=1.0*
 
     # Finally, install extruder
     - cmd: conda install extruder
-
-    # Install custom version of conda-build for now (need to be able to pass
-    # options to setup.py)
-    - cmd: conda install -c astropy-ci-extras conda-build=1.18.1
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
+    # Only upload if this is not a pull request
+    - if defined APPVEYOR_PULL_REQUEST_NUMBER (set UPLOAD=) else (set UPLOAD=--upload-channels %DESTINATION_CONDA_CHANNEL%)
+    - echo Upload is %UPLOAD%
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
     # Packages are uploaded as they are built.
-    - if exist recipes %CMD_IN_ENV% obvci_conda_build_dir --build-condition="python %PYTHON_BUILD_RESTRICTIONS%" recipes %DESTINATION_CONDA_CHANNEL%
+    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions="python %PYTHON_BUILD_RESTRICTIONS%"  --inspect-channels conda-forge %DESTINATION_CONDA_CHANNEL% %UPLOAD%

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.3.8'
+VERSION = '0.4.0.dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
This closes a number of issues and should have a minor impact on speed because it is no longer necessary to invoke a subprocess to generate skeletons
