### PR TITLE
Be more explicit bout dev version

### DIFF
--- a/extruder/extrude_recipes.py
+++ b/extruder/extrude_recipes.py
@@ -139,7 +139,8 @@ class Package(object):
 
     @property
     def is_dev(self):
-        return not (re.search('[a-zA-Z]', self.required_version) is None)
+        # Be more explicit about dev and pre-release versions
+        return not (re.search('a|b|rc|dev', self.required_version) is None)
 
     @property
     def url(self):


### PR DESCRIPTION
I fear this won't help in solving #26, but nevertheless a post release shouldn't be identified as a dev version. (probably RC versions either, but I've left them in for now).